### PR TITLE
Handle invalid image upload

### DIFF
--- a/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
+++ b/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
@@ -126,13 +126,17 @@ class PhotoController extends BaseController
 
                                 $filePath = TmpUpload::image($file, $this->tmpUploadDir);
 
+                                if ($filePath instanceof JsonResponse) {
+                                        return $filePath;
+                                }
+
                                 if ($filePath === null) {
                                         Log::error('Image upload failed', ['name' => $originalName]);
                                 } else {
                                         Log::info('Image uploaded', ['path' => $filePath]);
-                                }
 
-                                $picturesInput[] = $filePath;
+                                        $picturesInput[] = $filePath;
+                                }
 				
 				// Check the picture number limit
 				if ($key >= ($picturesLimit - 1)) {


### PR DESCRIPTION
## Summary
- prevent invalid image responses from crashing create photo upload

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fc0651d88321874759243221ae50