### PR TITLE
Fix temporary image upload handling

### DIFF
--- a/app/Helpers/Common/Files/TmpUpload.php
+++ b/app/Helpers/Common/Files/TmpUpload.php
@@ -40,13 +40,15 @@ class TmpUpload
         }
 
         $path = $file->getRealPath();
-        if (empty($path) || !is_file($path)) {
+        if (empty($path) || !file_exists($path)) {
                 Log::warning('Temporary file missing', [
-                        'file' => $file->getClientOriginalName(),
-                        'path' => $path,
+                        'file'       => $file->getClientOriginalName(),
+                        'path'       => (string)$path,
+                        'livewire'   => request()->header('X-Livewire') ? true : false,
+                        'files_count'=> is_countable(request()->file('pictures')) ? count(request()->file('pictures')) : 0,
                 ]);
 
-                return response()->json(['error' => 'Imagen no válida.'], 422);
+                return response()->json(['error' => 'El archivo temporal no se encuentra disponible.'], 422);
         }
 
         $disk = StorageDisk::getDisk();

--- a/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
+++ b/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
@@ -113,9 +113,16 @@ class PhotoController extends BaseController
 		
 		$picturesInput = [];
 		
-		// Save uploaded files
-		$files = $request->file('pictures');
-		if (is_array($files) && count($files) > 0) {
+                // Save uploaded files
+                $files = $request->file('pictures');
+                if (!is_array($files) || count($files) === 0) {
+                        Log::warning('postForm called without files', [
+                                'from_ajax' => isFromAjax($request),
+                                'count'     => is_countable($files) ? count($files) : 0,
+                        ]);
+                }
+
+                if (is_array($files) && count($files) > 0) {
                         foreach ($files as $key => $file) {
                                 if (empty($file)) {
                                         continue;


### PR DESCRIPTION
## Summary
- improve temp file validation in `TmpUpload::image`
- log when photo upload is attempted without files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685961940954832198b29ea9b1d9e808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for missing temporary files during uploads, providing more specific feedback.
  - Enhanced logging for missing or empty file uploads, including additional context to assist with troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->