### PR TITLE
Improve photo upload validation

### DIFF
--- a/resources/views/helpers/forms/fields/fileinput-ajax-multiple.blade.php
+++ b/resources/views/helpers/forms/fields/fileinput-ajax-multiple.blade.php
@@ -519,10 +519,23 @@
 				}
 			});
 			
-			{{-- After error occured during file batch upload hook --}}
-			dropzoneFieldEl.on('filebatchuploaderror', (event, data, errorMessage) => {
-				showErrorMessage(errorMessage, elSuccessContainer, elErrorContainer);
-			});
+                        {{-- After error occured during file batch upload hook --}}
+                        dropzoneFieldEl.on('filebatchuploaderror', (event, data, errorMessage) => {
+                                showErrorMessage(errorMessage, elSuccessContainer, elErrorContainer);
+                        });
+
+                        {{-- Single file upload error hook --}}
+                        dropzoneFieldEl.on('fileuploaderror', (event, data, msg) => {
+                                console.error('Upload error:', msg);
+                                if (data?.jqXHR?.status === 422) {
+                                        try {
+                                                const response = JSON.parse(data.jqXHR.responseText);
+                                                alert('Error: ' + response.error);
+                                        } catch (e) {
+                                                console.error(e);
+                                        }
+                                }
+                        });
 			
 			{{-- Before deletion hook --}}
 			dropzoneFieldEl.on('filepredelete', (event, key, jqXHR, data) => {


### PR DESCRIPTION
## Summary
- add detailed checks for missing or invalid temp files in photo uploads
- surface single file upload errors from bootstrap-fileinput

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685964473e04832180cf0655287c72ae