### PR TITLE
Fix manual file upload handling and temp cleanup

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -74,8 +74,10 @@ class AppServiceProvider extends ServiceProvider
                 $this->setupStorageSymlink();
 
                 // Ensure temporary storage directory exists
-                if (!Storage::exists('temp')) {
-                        Storage::makeDirectory('temp');
+                $tempPath = storage_path('app/temp');
+                if (!is_dir($tempPath)) {
+                        mkdir($tempPath, 0755, true);
+                        \Log::info('Created temp directory', ['path' => $tempPath]);
                 }
 		
 		// Setup ACL system


### PR DESCRIPTION
## Summary
- add debug file analysis to uploadPhotos
- replace Storage::putFileAs with manual file copy
- create cleanup routine for old temp files
- ensure temp directory creation via AppServiceProvider

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68596c2ee5108321a3fb10e208269c5b