### PR TITLE
Fix install route action

### DIFF
--- a/routes/web/setup.php
+++ b/routes/web/setup.php
@@ -38,8 +38,8 @@ Route::middleware(['no.http.cache'])
 		Route::middleware(['install'])
 			->prefix('install')
 			->group(function () {
-				Route::get('/', StartingController::class);
-				Route::get('system_requirements', RequirementsController::class);
+                                Route::get('/', [StartingController::class, '__invoke']);
+                                Route::get('system_requirements', [RequirementsController::class, '__invoke']);
 				Route::controller(SiteInfoController::class)
 					->group(function () {
 						Route::get('site_info', 'showForm');
@@ -55,7 +55,7 @@ Route::middleware(['no.http.cache'])
 						Route::get('database_import', 'showForm');
 						Route::post('database_import', 'postForm');
 					});
-				Route::get('cron_jobs', CronController::class);
-				Route::get('finish', FinishController::class);
+                                Route::get('cron_jobs', [CronController::class, '__invoke']);
+                                Route::get('finish', [FinishController::class, '__invoke']);
 			});
 	});


### PR DESCRIPTION
## Summary
- fix bad controller mapping for install routes

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859880be95883219ea78533ede89a3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated route definitions to explicitly specify controller methods for single-action routes in the installation process. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->