### PR TITLE
Fix route namespace duplication

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -27,14 +27,14 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::namespace('Web\\Setup')->group(__DIR__ . '/web/setup.php');
+require __DIR__ . '/web/setup.php';
 
 Route::middleware(['installed'])
 	->group(function () {
 		$authBasePath = urlGen()->getAuthBasePath();
 		$adminBasePath = urlGen()->getAdminBasePath();
 		
-                Route::namespace('Web\\Auth')->prefix($authBasePath)->group(__DIR__ . '/web/auth.php');
-                Route::namespace('Web\\Admin')->prefix($adminBasePath)->group(__DIR__ . '/web/admin.php');
-                Route::namespace('Web\\Front')->group(__DIR__ . '/web/front.php');
-	});
+               Route::prefix($authBasePath)->group(__DIR__ . '/web/auth.php');
+               Route::prefix($adminBasePath)->group(__DIR__ . '/web/admin.php');
+               require __DIR__ . '/web/front.php';
+        });


### PR DESCRIPTION
## Summary
- load route files directly without namespace prefixing to avoid duplicated controller paths

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685989b8737c8321a2fcca6ed9b3a421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated routing setup to simplify route file inclusion and remove explicit namespace declarations from route groups. No impact on existing features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->