### PR TITLE
Fix routing namespace duplication

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,19 +7,17 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
-	->withRouting(
-		using: function () {
-			// api
-			Route::middleware('api')
-				->namespace('App\Http\Controllers\Api')
-				->prefix('api')
-				->group(base_path('routes/api.php'));
-			
-			// web
-			Route::middleware('web')
-				->namespace('App\Http\Controllers\Web')
-				->group(base_path('routes/web.php'));
-		},
+        ->withRouting(
+                using: function () {
+                        // api
+                        Route::middleware('api')
+                                ->prefix('api')
+                                ->group(base_path('routes/api.php'));
+
+                        // web
+                        Route::middleware('web')
+                                ->group(base_path('routes/web.php'));
+                },
 		commands: __DIR__ . '/../routes/console.php',
 		// health: '/up',
 	)


### PR DESCRIPTION
## Summary
- stop adding namespace prefixes for routed controllers

## Testing
- `phpunit --version` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599c6099048321b3ca439760efd12d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated routing configuration to simplify route group settings. No changes to visible application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->