### PR TITLE
Fix AutoComplete route in front web routes

### DIFF
--- a/routes/web/front.php
+++ b/routes/web/front.php
@@ -238,7 +238,7 @@ Route::prefix('browsing')
 			});
                 // Location
                 $router->pattern('countryCode', getCountryCodeRoutePattern());
-                Route::post('countries/{countryCode}/cities/autocomplete', AutoCompleteController::class);
+                Route::post('countries/{countryCode}/cities/autocomplete', [AutoCompleteController::class, '__invoke']);
                 Route::controller(SelectBoxController::class)
                         ->group(function ($router) {
                                 $router->pattern('id', '[0-9]+');


### PR DESCRIPTION
## Summary
- specify the method to call in the cities autocomplete route

## Testing
- `./vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c146d474832181dac6fad987cb84