### PR TITLE
Improve error handling and remove die calls

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -112,10 +112,14 @@ class Handler extends ExceptionHandler
 				}
 			}
 			
-			if (appInstallFilesExist()) {
-				$this->sendNotification($e);
-			}
-		});
+                        if (appInstallFilesExist()) {
+                                try {
+                                        $this->sendNotification($e);
+                                } catch (\Throwable $notificationException) {
+                                        // Do not interrupt the reporting process if notification fails
+                                }
+                        }
+                });
 		
 		/*
 		 * Render an exception into an HTTP response

--- a/app/Exceptions/Handler/Traits/NotificationTrait.php
+++ b/app/Exceptions/Handler/Traits/NotificationTrait.php
@@ -27,9 +27,9 @@ trait NotificationTrait
 	 */
 	public function sendNotification(\Throwable $e): void
 	{
-		if ($this->isFullMemoryException($e)) {
-			die($e->getMessage());
-		}
+                if ($this->isFullMemoryException($e)) {
+                        throw $e;
+                }
 		
 		if (appIsBeingInstalled()) {
 			return;

--- a/app/Helpers/Common/Curl.php
+++ b/app/Helpers/Common/Curl.php
@@ -129,17 +129,17 @@ class Curl
 		$error = curl_error($ch);
 		curl_close($ch);
 		
-		if ($buffer) {
-			if (file_exists($saveTo)) {
-				unlink($saveTo);
-			}
-			if (self::filePutContents($saveTo, $buffer) === false) {
-				die($url . " doesn't save at " . $saveTo . ".\n");
-			}
-		} else {
-			die($error);
-		}
-	}
+                if ($buffer) {
+                        if (file_exists($saveTo)) {
+                                unlink($saveTo);
+                        }
+                        if (!self::filePutContents($saveTo, $buffer)) {
+                                throw new \RuntimeException($url . " doesn't save at " . $saveTo . ".\n");
+                        }
+                } else {
+                        throw new \RuntimeException($error);
+                }
+        }
 	
 	/**
 	 * @param $url
@@ -233,8 +233,8 @@ class Curl
 	 * @param int $flags
 	 * @param null $context
 	 */
-	public static function filePutContents($filename, $data, int $flags = 0, $context = null): void
-	{
+        public static function filePutContents($filename, $data, int $flags = 0, $context = null): bool
+        {
 		$tmp = explode('/', $filename);
 		$shortFilename = array_pop($tmp);
 		
@@ -248,6 +248,6 @@ class Curl
 		
 		$filename = $filePath . '/' . $shortFilename;
 		
-		file_put_contents($filename, $data, $flags, $context);
-	}
+                return file_put_contents($filename, $data, $flags, $context) !== false;
+        }
 }

--- a/app/Helpers/Services/Localization/Helpers/Country.php
+++ b/app/Helpers/Services/Localization/Helpers/Country.php
@@ -48,17 +48,17 @@ class Country
 	 */
 	protected $countries = [];
 	
-	public function __construct($dataDir = null)
-	{
-		if (isset($dataDir)) {
-			if (!is_dir($dataDir)) {
-				die(sprintf('Unable to locate the country data directory at "%s"', $dataDir));
-			}
-			$this->dataDir = $dataDir;
-		} else {
-			$this->dataDir = base_path('database/umpirsky/country');
-		}
-	}
+        public function __construct($dataDir = null)
+        {
+                if (isset($dataDir)) {
+                        if (!is_dir($dataDir)) {
+                                throw new \InvalidArgumentException(sprintf('Unable to locate the country data directory at "%s"', $dataDir));
+                        }
+                        $this->dataDir = $dataDir;
+                } else {
+                        $this->dataDir = base_path('database/umpirsky/country');
+                }
+        }
 	
 	/**
 	 * Returns one country.

--- a/app/Helpers/Services/Localization/Language.php
+++ b/app/Helpers/Services/Localization/Language.php
@@ -308,9 +308,14 @@ class Language
 			return collect();
 		}
 		
-		// $locale = 'en'; // debug
-		$countryLang = new CountryHelper();
-		$tab = [];
+                // $locale = 'en'; // debug
+                try {
+                        $countryLang = new CountryHelper();
+                } catch (\InvalidArgumentException $e) {
+                        return collect();
+                }
+
+                $tab = [];
 		foreach ($countries as $code => $country) {
 			$tab[$code] = $country;
 			if ($name = $countryLang->get($code, $locale, $source)) {
@@ -340,13 +345,18 @@ class Language
 			return collect();
 		}
 		
-		// $locale = 'en'; // debug
-		$countryLang = new CountryHelper();
-		if ($name = $countryLang->get($country->get('code'), $locale, $source)) {
-			return $country->merge(['name' => $name]);
-		} else {
-			return $country;
-		}
+                // $locale = 'en'; // debug
+                try {
+                        $countryLang = new CountryHelper();
+                } catch (\InvalidArgumentException $e) {
+                        return $country;
+                }
+
+                if ($name = $countryLang->get($country->get('code'), $locale, $source)) {
+                        return $country->merge(['name' => $name]);
+                } else {
+                        return $country;
+                }
 	}
 	
 	/**

--- a/app/Models/Traits/CountryTrait.php
+++ b/app/Models/Traits/CountryTrait.php
@@ -85,8 +85,12 @@ trait CountryTrait
 		$languages = DB::table((new Language())->getTable())->get();
 		$oldEntries = DB::table($tableName)->get();
 		
-		if ($oldEntries->count() > 0) {
-			$transCountry = new CountryHelper();
+                if ($oldEntries->count() > 0) {
+                        try {
+                                $transCountry = new CountryHelper();
+                        } catch (\InvalidArgumentException $e) {
+                                return;
+                        }
 			foreach ($oldEntries as $oldEntry) {
 				$newNames = [];
 				


### PR DESCRIPTION
## Summary
- throw `RuntimeException` in `Curl::grabFile()` on errors
- throw `InvalidArgumentException` if localization data folder is missing
- rethrow memory exceptions in `NotificationTrait` instead of dying
- handle notification errors gracefully in the exception handler
- protect translators from missing country data

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859eba168848321809453413994a364