### PR TITLE
Fix CLDR data source

### DIFF
--- a/app/Helpers/Services/Localization/Helpers/Country.php
+++ b/app/Helpers/Services/Localization/Helpers/Country.php
@@ -32,7 +32,7 @@ class Country
 	 * @var array
 	 * Available data sources.
 	 */
-	protected $dataSources = ['icu', 'icu'];
+        protected $dataSources = ['icu', 'cldr'];
 	
 	/**
 	 * The name of the country list file
@@ -135,13 +135,14 @@ class Country
 			$locale = config('app.locale');
 		}
 		
-		$source = (!empty($source)) ? mb_strtolower($source) . '/' : '';
-		
-		if (!empty($source) && !in_array($source, $this->dataSources)) {
-			return [];
-		}
-		
-		$file = $this->dataDir . '/' . $source . $locale . '/' . $this->filename;
+                $source = (!empty($source)) ? mb_strtolower($source) : '';
+
+                if (!empty($source) && !in_array($source, $this->dataSources)) {
+                        return [];
+                }
+
+                $sourceDir = ($source === 'icu') ? $source . '/' : '';
+                $file = $this->dataDir . '/' . $sourceDir . $locale . '/' . $this->filename;
 		if (!file_exists($file)) {
 			return [];
 		}

--- a/tests/Unit/CountryHelperTest.php
+++ b/tests/Unit/CountryHelperTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\Services\Localization\Helpers\Country;
+use Tests\TestCase;
+
+class CountryHelperTest extends TestCase
+{
+    public function testLoadDataCldrReturnsData(): void
+    {
+        $helper = new Country();
+        $data = $helper->loadData('php', 'en', 'cldr');
+
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+    }
+}


### PR DESCRIPTION
## Summary
- support `cldr` data source in Country helper
- add unit test for `loadData('php','en','cldr')`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --testsuite Unit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859eba5c16483219f31e9062818c4cf