### PR TITLE
Fix temporary image upload path

### DIFF
--- a/app/Console/Commands/CleanTempFiles.php
+++ b/app/Console/Commands/CleanTempFiles.php
@@ -22,7 +22,7 @@ class CleanTempFiles extends Command
 
     public function handle(): void
     {
-        $tempPath = storage_path('app/temp');
+        $tempPath = storage_path('app/temporary');
         $files = glob($tempPath . '/*');
         $now = time();
 

--- a/app/Helpers/Common/Files/TmpUpload.php
+++ b/app/Helpers/Common/Files/TmpUpload.php
@@ -69,7 +69,8 @@ class TmpUpload
                 }
         }
 
-        $disk = StorageDisk::getDisk();
+        // Use the local disk for temporary files
+        $disk = StorageDisk::getDisk('local');
 		
 		try {
 			// Get file's original infos
@@ -147,9 +148,15 @@ class TmpUpload
 			// Get the file path
 			$filePath = $tmpUploadDir . '/' . $filename;
 			
-			// Store the image on disk
-			$disk->put($filePath, $encodedImage->toString());
-			unset($encodedImage);
+        // Store the image on disk
+        $disk->put($filePath, $encodedImage->toString());
+        unset($encodedImage);
+
+        Log::info('Temporary image stored', [
+            'disk'   => 'local',
+            'path'   => $filePath,
+            'exists' => $disk->exists($filePath),
+        ]);
 			
 			// Return the path (to the database later)
 			return $filePath;
@@ -187,7 +194,8 @@ class TmpUpload
 			return null;
 		}
 		
-		$disk = StorageDisk::getDisk();
+        // Use the local disk for temporary files
+        $disk = StorageDisk::getDisk('local');
 		
 		try {
 			// Get file original infos
@@ -201,11 +209,17 @@ class TmpUpload
 			// Get filepath
 			$filePath = $tmpUploadDir . '/' . $filename;
 			
-			// Store the file on disk
-			$disk->put($filePath, File::get($file->getrealpath()));
-			
-			// Return the path (to the database later)
-			return $filePath;
+        // Store the file on disk
+        $disk->put($filePath, File::get($file->getrealpath()));
+
+        Log::info('Temporary file stored', [
+            'disk'   => 'local',
+            'path'   => $filePath,
+            'exists' => $disk->exists($filePath),
+        ]);
+
+        // Return the path (to the database later)
+        return $filePath;
 		} catch (Throwable $e) {
 		}
 		

--- a/app/Helpers/Common/Files/Upload.php
+++ b/app/Helpers/Common/Files/Upload.php
@@ -272,11 +272,20 @@ class Upload
 	 */
 	public static function fromPath(string $path, bool $test = true): bool|UploadedFile
 	{
-		if (empty($path) || !Storage::exists($path)) {
-			return false;
-		}
-		
-		$path = Storage::path($path);
+        if (empty($path)) {
+                return false;
+        }
+
+        // Try the local disk first for temporary files
+        if (Storage::disk('local')->exists($path)) {
+                $path = Storage::disk('local')->path($path);
+                Log::info('fromPath using local disk', ['path' => $path]);
+        } elseif (Storage::exists($path)) {
+                $path = Storage::path($path);
+                Log::info('fromPath using default disk', ['path' => $path]);
+        } else {
+                return false;
+        }
 		
 		$filesystem = new Filesystem();
 		$originalName = $filesystem->name($path) . '.' . $filesystem->extension($path);

--- a/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
+++ b/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
@@ -524,7 +524,8 @@ class PhotoController extends BaseController
                                 ]);
 
                                 // AGREGAR LOG: DESPUÉS de guardar el archivo temporal
-                                $disk = StorageDisk::getDisk();
+                                // Use local disk for temporary files
+                                $disk = StorageDisk::getDisk('local');
                                 $fileExistsAfterSave = $disk->exists($filePath);
                                 $fileSizeAfterSave = $fileExistsAfterSave ? $disk->size($filePath) : 'not_found';
                                 
@@ -532,7 +533,7 @@ class PhotoController extends BaseController
                                         'save_result' => $fileExistsAfterSave,
                                         'file_exists_after_save' => $fileExistsAfterSave,
                                         'file_size_after_save' => $fileSizeAfterSave,
-                                        'full_path_verification' => file_exists(storage_path('app/' . $filePath)),
+                                        'full_path_verification' => Storage::disk('local')->exists($filePath),
                                         'temporary_directory_contents' => $disk->files(dirname($filePath)),
                                 ]);
 
@@ -564,7 +565,8 @@ class PhotoController extends BaseController
         
         private function cleanupOldTempFiles()
         {
-                $disk = StorageDisk::getDisk();
+                // Use local disk to clean temporary files
+                $disk = StorageDisk::getDisk('local');
                 $tempDir = $disk->path('temporary');
 
                 if (!is_dir($tempDir)) {

--- a/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/Traits/ClearTmpInputTrait.php
+++ b/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/Traits/ClearTmpInputTrait.php
@@ -16,6 +16,7 @@
 
 namespace App\Http\Controllers\Web\Front\Post\CreateOrEdit\MultiSteps\Create\Traits;
 
+use Illuminate\Support\Facades\Storage;
 use Throwable;
 
 trait ClearTmpInputTrait
@@ -32,14 +33,17 @@ trait ClearTmpInputTrait
 		if (session()->has('picturesInput')) {
 			$picturesInput = (array)session('picturesInput');
 			if (!empty($picturesInput)) {
-				try {
-					foreach ($picturesInput as $filePath) {
-						$this->removePictureWithItsThumbs($filePath);
-					}
-				} catch (Throwable $e) {
-					$message = $e->getMessage();
-					flash($message)->error();
-				}
+                                try {
+                                        $disk = Storage::disk('local');
+                                        foreach ($picturesInput as $filePath) {
+                                                if ($disk->exists($filePath)) {
+                                                        $disk->delete($filePath);
+                                                }
+                                        }
+                                } catch (Throwable $e) {
+                                        $message = $e->getMessage();
+                                        flash($message)->error();
+                                }
 				session()->forget('picturesInput');
 			}
 		}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -74,10 +74,10 @@ class AppServiceProvider extends ServiceProvider
                 $this->setupStorageSymlink();
 
                 // Ensure temporary storage directory exists
-                $tempPath = storage_path('app/temp');
+                $tempPath = storage_path('app/temporary');
                 if (!is_dir($tempPath)) {
                         mkdir($tempPath, 0755, true);
-                        \Log::info('Created temp directory', ['path' => $tempPath]);
+                        \Log::info('Created temporary directory', ['path' => $tempPath]);
                 }
 		
 		// Setup ACL system


### PR DESCRIPTION
## Summary
- use local disk for temporary images
- log temporary storage writes and Upload::fromPath disk choices
- clean up local temp files when clearing session
- ensure temporary directory is created under `storage/app/temporary`
- clean temp files command looks in new directory
- adjust PhotoController to read/write temporary files on local disk

## Testing
- `bash test_upload_flow.sh` *(fails: `php: command not found`)*
- `bash test_file_persistence.sh` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a22b9bec483219eee3956eb2e67b8