### PR TITLE
Fix handling of temporary image paths

### DIFF
--- a/app/Helpers/Services/Functions/core.php
+++ b/app/Helpers/Services/Functions/core.php
@@ -32,6 +32,7 @@ use Hashids\Hashids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
+use Illuminate\Support\Str;
 use Intervention\Image\Laravel\Facades\Image as FacadeImage;
 use Larapen\LaravelDistance\Helper;
 use Larapen\TextToImage\Facades\TextToImage;
@@ -2784,7 +2785,9 @@ function isMultiCountriesUrlsEnabled(): bool
  */
 function hasTemporaryPath(string $filePath): bool
 {
-	return str_starts_with($filePath, 'temporary' . DIRECTORY_SEPARATOR);
+        $normalizedPath = str_replace('\\', '/', $filePath);
+
+        return Str::startsWith($normalizedPath, 'temporary/');
 }
 
 /**

--- a/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
+++ b/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/PhotoController.php
@@ -555,7 +555,8 @@ class PhotoController extends BaseController
                 $newPicturesInput = array_merge($savedPicturesInput, $picturesInput);
                 session()->put('picturesInput', $newPicturesInput);
 
-                $this->cleanupOldTempFiles();
+                // Avoid deleting temporary files here. Cleanup will be
+                // performed later by a scheduled command.
 
                 return response()->json([
                         'message' => 'Archivos subidos correctamente',
@@ -565,7 +566,10 @@ class PhotoController extends BaseController
         
         private function cleanupOldTempFiles()
         {
-                // Use local disk to clean temporary files
+                // Kept for reference. Actual deletion should be handled by a
+                // scheduled command to avoid removing files before they are
+                // processed.
+
                 $disk = StorageDisk::getDisk('local');
                 $tempDir = $disk->path('temporary');
 
@@ -578,8 +582,7 @@ class PhotoController extends BaseController
 
                 foreach ($files as $file) {
                         if (is_file($file) && ($now - filemtime($file)) >= 3600) {
-                                unlink($file);
-                                Log::debug('Cleaned old temp file', ['file' => basename($file)]);
+                                Log::debug('Old temp file detected', ['file' => basename($file)]);
                         }
                 }
         }


### PR DESCRIPTION
## Summary
- normalize temporary path detection to accept nested folders
- skip deleting temporary files during upload

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*
- `bash test_file_persistence.sh` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a26a249808321b7ce9e3a85c4437f