### PR TITLE
Fix temporary image checks

### DIFF
--- a/app/Helpers/Common/Files/FileSys.php
+++ b/app/Helpers/Common/Files/FileSys.php
@@ -21,6 +21,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\Mime\MimeTypes;
+use Illuminate\Support\Str;
 use Throwable;
 
 class FileSys
@@ -341,16 +342,30 @@ class FileSys
 	 * @param string|null $filename
 	 * @return string|null
 	 */
-	public static function getPathInfoExtension(?string $filename): ?string
-	{
-		if (empty($filename)) return null;
-		if (!str_contains($filename, '.')) return null;
-		
-		$extension = pathinfo($filename, PATHINFO_EXTENSION);
-		$extension = !empty($extension) ? ltrim($extension, '.') : null;
-		
-		return !empty($extension) ? strtolower($extension) : null;
-	}
+
+        public static function getPathInfoExtension(?string $filename): ?string
+        {
+                if (empty($filename)) return null;
+                if (!str_contains($filename, '.')) return null;
+
+                $extension = pathinfo($filename, PATHINFO_EXTENSION);
+                $extension = !empty($extension) ? ltrim($extension, '.') : null;
+
+                return !empty($extension) ? strtolower($extension) : null;
+        }
+
+        /**
+         * Determine if the given path refers to a temporary file.
+         *
+         * @param string $path
+         * @return bool
+         */
+        public static function isTemporaryPath(string $path): bool
+        {
+                $normalizedPath = str_replace('\\', '/', $path);
+
+                return Str::startsWith($normalizedPath, 'temporary/');
+        }
 	
 	// OTHER
 	

--- a/app/Helpers/Services/Functions/core.php
+++ b/app/Helpers/Services/Functions/core.php
@@ -18,6 +18,7 @@ use App\Helpers\Common\Arr;
 use App\Helpers\Common\DBUtils;
 use App\Helpers\Common\DotenvEditor;
 use App\Helpers\Common\Files\Storage\StorageDisk;
+use App\Helpers\Common\Files\FileSys;
 use App\Helpers\Services\Localization\Country as CountryHelper;
 use App\Helpers\Services\Localization\Helpers\Country;
 use App\Models\Language;
@@ -2785,9 +2786,7 @@ function isMultiCountriesUrlsEnabled(): bool
  */
 function hasTemporaryPath(string $filePath): bool
 {
-        $normalizedPath = str_replace('\\', '/', $filePath);
-
-        return Str::startsWith($normalizedPath, 'temporary/');
+        return FileSys::isTemporaryPath($filePath);
 }
 
 /**

--- a/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/Traits/ClearTmpInputTrait.php
+++ b/app/Http/Controllers/Web/Front/Post/CreateOrEdit/MultiSteps/Create/Traits/ClearTmpInputTrait.php
@@ -17,6 +17,7 @@
 namespace App\Http\Controllers\Web\Front\Post\CreateOrEdit\MultiSteps\Create\Traits;
 
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 trait ClearTmpInputTrait
@@ -30,23 +31,18 @@ trait ClearTmpInputTrait
 			session()->forget('postInput');
 		}
 		
-		if (session()->has('picturesInput')) {
-			$picturesInput = (array)session('picturesInput');
-			if (!empty($picturesInput)) {
-                                try {
-                                        $disk = Storage::disk('local');
-                                        foreach ($picturesInput as $filePath) {
-                                                if ($disk->exists($filePath)) {
-                                                        $disk->delete($filePath);
-                                                }
-                                        }
-                                } catch (Throwable $e) {
-                                        $message = $e->getMessage();
-                                        flash($message)->error();
-                                }
-				session()->forget('picturesInput');
-			}
-		}
+                if (session()->has('picturesInput')) {
+                        $picturesInput = (array)session('picturesInput');
+                        if (!empty($picturesInput)) {
+                                // Removal of temporary files is deferred to a scheduled command
+                                // to avoid deleting files that may still be needed.
+                                Log::info('Skipping immediate deletion of temporary files', [
+                                        'files' => $picturesInput,
+                                ]);
+
+                                session()->forget('picturesInput');
+                        }
+                }
 		
 		if (session()->has('paymentInput')) {
 			session()->forget('paymentInput');


### PR DESCRIPTION
## Summary
- centralize temporary file path check in FileSys
- use new helper from `hasTemporaryPath`
- avoid deleting temp files during clear step

## Testing
- `composer test` *(fails: composer not installed)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a2e3d7e848321b8eded46ef18db5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new method to help identify temporary file paths.

- **Refactor**
  - Improved internal handling of temporary file path checks for consistency.
  - Temporary files are no longer deleted immediately during post creation or editing; removal is now handled by a scheduled process.

- **Chores**
  - Added logging to inform users when immediate deletion of temporary files is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->