### PR TITLE
Improve upload flow with validation and logging

### DIFF
--- a/app/Http/Controllers/Api/UploadController.php
+++ b/app/Http/Controllers/Api/UploadController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\ImageProcessingService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class UploadController extends Controller
+{
+    protected ImageProcessingService $service;
+
+    public function __construct(ImageProcessingService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'files.*' => 'required|file|mimes:jpg,jpeg,png,gif'
+        ]);
+
+        $config = Cache::remember('php_upload_config', 3600, function () {
+            return [
+                'upload_max_filesize' => ini_get('upload_max_filesize'),
+                'post_max_size'      => ini_get('post_max_size'),
+                'max_file_uploads'   => ini_get('max_file_uploads'),
+                'upload_tmp_dir'     => ini_get('upload_tmp_dir'),
+                'memory_limit'       => ini_get('memory_limit'),
+            ];
+        });
+        Log::channel('upload')->info('php_config', $config);
+
+        $files = (array) $request->file('files');
+        $dest = 'uploads/'.date('Y/m/d');
+        $absolute = realpath(storage_path('app/public/'.$dest));
+        if ($absolute === false) {
+            $absolute = Storage::disk('public')->path($dest);
+        }
+
+        $results = [];
+        foreach ($files as $file) {
+            $results[] = $this->service->handle($file, $dest);
+        }
+
+        return response()->json(['success' => true, 'files' => $results], 201);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -129,8 +129,9 @@ class Kernel
 			'installed'     => \App\Http\Middleware\Installed::class,
 			'clearance'     => \App\Http\Middleware\Clearance::class,
 			'no.http.cache' => \App\Http\Middleware\NoHttpCache::class,
-			'only.ajax'     => \App\Http\Middleware\OnlyAjax::class,
-		]);
+                        'only.ajax'     => \App\Http\Middleware\OnlyAjax::class,
+                        'upload.validation' => \App\Http\Middleware\UploadValidationMiddleware::class,
+                ]);
 		
 		/*
 		 * The priority-sorted list of middleware

--- a/app/Http/Middleware/UploadValidationMiddleware.php
+++ b/app/Http/Middleware/UploadValidationMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class UploadValidationMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->isMethod('post') && $request->hasFile('files')) {
+            $files = (array) $request->file('files');
+            if (count($files) > 5) {
+                Log::warning('Too many files uploaded', ['count' => count($files)]);
+                return response()->json(['message' => 'Maximum 5 files allowed'], 422);
+            }
+
+            // Rate limit per IP
+            $key = 'upload_rate:'. $request->ip();
+            $attempts = Cache::increment($key);
+            Cache::put($key, $attempts, now()->addMinute());
+            if ($attempts > 20) {
+                Log::warning('Upload rate limit exceeded', ['ip' => $request->ip()]);
+                return response()->json(['message' => 'Too many upload attempts'], 429);
+            }
+
+            // Check checksum header if provided
+            if ($checksum = $request->header('X-Checksum')) {
+                $computed = hash('sha256', $request->getContent());
+                if (!hash_equals($checksum, $computed)) {
+                    Log::error('Checksum mismatch');
+                    return response()->json(['message' => 'Invalid request checksum'], 400);
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Logging/CreateSizeRotatingLogger.php
+++ b/app/Logging/CreateSizeRotatingLogger.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Logging;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Illuminate\Support\Facades\File;
+
+class CreateSizeRotatingLogger
+{
+    public function __invoke(array $config): Logger
+    {
+        $path = $config['path'];
+        $level = Logger::toMonologLevel($config['level'] ?? Logger::DEBUG);
+        $max = $config['max_bytes'] ?? 5242880; // 5MB
+
+        if (File::exists($path) && File::size($path) >= $max) {
+            $archive = $path.'.'.date('Ymd_His');
+            File::move($path, $archive);
+        }
+
+        $handler = new StreamHandler($path, $level);
+        return new Logger('size_rotate', [$handler]);
+    }
+}

--- a/app/Services/ImageProcessingService.php
+++ b/app/Services/ImageProcessingService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Intervention\Image\Laravel\Facades\Image;
+use Throwable;
+
+class ImageProcessingService
+{
+    /**
+     * Handle an uploaded image, preserving size and verifying integrity.
+     *
+     * @param UploadedFile $file
+     * @param string $destPath Absolute destination path on disk
+     * @return array{path:string,size:int}
+     */
+    public function handle(UploadedFile $file, string $destPath): array
+    {
+        $disk = Storage::disk('public');
+
+        $originalSize = $file->getSize();
+        $beforeHash = hash_file('sha256', $file->getRealPath());
+
+        try {
+            $image = Image::read($file);
+            $extension = $file->getClientOriginalExtension() ?: 'jpg';
+            $filename = Str::uuid()->toString().'.'.$extension;
+
+            // Encode image to preserve quality
+            $encoded = $image->encode($extension, 90);
+            $disk->put($destPath.'/'.$filename, $encoded->toString());
+            unset($encoded);
+
+            $storedPath = $disk->path($destPath.'/'.$filename);
+            $finalSize = filesize($storedPath);
+            $afterHash = hash_file('sha256', $storedPath);
+
+            if (!$afterHash || $afterHash !== $beforeHash) {
+                // Integrity failed
+                $disk->delete($destPath.'/'.$filename);
+                throw new \RuntimeException('Checksum mismatch after processing');
+            }
+
+            if ($finalSize > $originalSize * 1.05) {
+                Log::warning('Image size increased', [
+                    'orig' => $originalSize,
+                    'final' => $finalSize,
+                ]);
+                if ($finalSize > $originalSize * 1.30) {
+                    Log::channel('upload')->error('Critical size increase', [
+                        'orig' => $originalSize,
+                        'final' => $finalSize,
+                    ]);
+                }
+            }
+
+            return ['path' => $destPath.'/'.$filename, 'size' => $finalSize];
+        } catch (Throwable $e) {
+            Log::channel('upload')->error('Processing failed', [
+                'message' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -119,11 +119,19 @@ return [
 			'replace_placeholders' => true,
 		],
 		
-		'errorlog' => [
-			'driver' => 'errorlog',
-			'level'  => env('LOG_LEVEL', 'debug'),
-			'replace_placeholders' => true,
-		],
+                'errorlog' => [
+                        'driver' => 'errorlog',
+                        'level'  => env('LOG_LEVEL', 'debug'),
+                        'replace_placeholders' => true,
+                ],
+
+                'upload' => [
+                        'driver' => 'custom',
+                        'via'    => App\Logging\CreateSizeRotatingLogger::class,
+                        'path'   => storage_path('logs/upload.log'),
+                        'level'  => env('LOG_LEVEL', 'info'),
+                        'max_bytes' => 5 * 1024 * 1024,
+                ],
 		
 		'null' => [
 			'driver'  => 'monolog',

--- a/routes/api.php
+++ b/routes/api.php
@@ -295,11 +295,16 @@ Route::prefix('pictures')
 		Route::post('reorder', 'reorder')->name('pictures.reorder'); // Bulk Update
 	});
 Route::prefix('posts')
-	->controller(PictureController::class)
-	->group(function ($router) {
-		$router->pattern('postId', '[0-9]+');
-		Route::get('{postId}/pictures', 'index')->name('posts.pictures');
-	});
+        ->controller(PictureController::class)
+        ->group(function ($router) {
+                $router->pattern('postId', '[0-9]+');
+                Route::get('{postId}/pictures', 'index')->name('posts.pictures');
+        });
+
+// uploads
+Route::post('uploads', [\App\Http\Controllers\Api\UploadController::class, 'store'])
+        ->middleware('upload.validation')
+        ->name('uploads.store');
 
 // packages (promotion|subscription)
 Route::prefix('packages')

--- a/tests/Feature/UploadControllerTest.php
+++ b/tests/Feature/UploadControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UploadControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_upload_more_than_five_files(): void
+    {
+        Storage::fake('public');
+
+        $files = [];
+        for ($i = 0; $i < 6; $i++) {
+            $files[] = UploadedFile::fake()->image("photo{$i}.jpg");
+        }
+
+        $response = $this->postJson('/api/uploads', ['files' => $files]);
+        $response->assertStatus(422);
+    }
+
+    public function test_successful_upload(): void
+    {
+        Storage::fake('public');
+
+        $files = [
+            UploadedFile::fake()->image('a.jpg'),
+            UploadedFile::fake()->image('b.jpg'),
+        ];
+
+        $response = $this->postJson('/api/uploads', ['files' => $files]);
+        $response->assertStatus(201);
+    }
+}


### PR DESCRIPTION
## Summary
- add controller for uploads with size checks and real path handling
- enforce upload request limits and checksum validation middleware
- implement image processing service with integrity checks
- rotate logs when upload log exceeds 5 MB
- wire new middleware and route
- add feature tests for upload controller

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ee30b6710832194598a39bd4b50e2